### PR TITLE
Restauração da configuração do SonarCloud para o projeto pai

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <spring.boot.maven.plugin>3.5.3</spring.boot.maven.plugin>
         <org.projectlombok.version>1.18.38</org.projectlombok.version>
         <springboot.starter.test.version>3.5.3</springboot.starter.test.version>
+        <sonar.organization>dickson-souza-projects-sonarqube-cloud</sonar.organization>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
A configuração para execução da análise de código pelo SonarCloud foi reestabelecida, considerando o projeto pai e analisando cada módulo ao mesmo tempo. Uma separação posterior é possível de ser feita.

O link para o SonarQube Cloud é: 

https://sonarcloud.io/project/overview?id=base_project